### PR TITLE
Support for Debian family and other changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
 #  - distro: centos6
 #  - distro: fedora24
 #  - distro: ubuntu1604
-#  - distro: ubuntu1404
+  - distro: ubuntu1404
 #  - distro: ubuntu1204
 #  - distro: debian8
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ None.
     # JVM max and min memory space
     bamboo_master_jvm_memory: 1g
 
+    # Set False to disable inclusion of cron package and cron tasks
+    bamboo_include_cron: True
+
+    # Set False to disable OpenJDK inclusion
+    bamboo_include_jdk: True
+
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,8 @@ bamboo_master_user: bamboo
 bamboo_master_application_folder: "/opt/atlassian/bamboo"
 bamboo_master_data_folder: "/var/atlassian/application-data/bamboo"
 bamboo_master_jvm_memory: 1g
+bamboo_include_cron: True
+bamboo_include_jdk: True
 
 openjdk_version: 1.8.0
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,3 +5,11 @@
     state: restarted
     enabled: yes
     daemon_reload: yes
+  when: ansible_service_mgr == 'systemd'
+
+- name: restart bamboo
+  service:
+    name: bamboo
+    state: restarted
+    enabled: yes
+  when: ansible_service_mgr == 'service'

--- a/tasks/bamboo.yml
+++ b/tasks/bamboo.yml
@@ -6,7 +6,7 @@
 - name: Add local user
   user:
     name: "{{ bamboo_master_user }}"
-    home: "{{ bamboo_master_data_folder }}"
+    createhome: no
 
 - name: Create app and data folders
   file:
@@ -17,6 +17,11 @@
   with_items:
     - "{{ bamboo_master_application_folder }}"
     - "{{ bamboo_master_data_folder }}"
+
+- name: Set local user home directory
+  user:
+    name: "{{ bamboo_master_user }}"
+    home: "{{ bamboo_master_data_folder }}"
 
 - name: Check for downgrade
   fail: msg="Downgrades are not supported. Please set bamboo_version to higher or equal to {{ ansible_local.bamboo.version }}. Current value is {{ bamboo_master.version }}"

--- a/tasks/bamboo.yml
+++ b/tasks/bamboo.yml
@@ -3,25 +3,12 @@
   set_fact:
     bamboo_master_binary_folder: "{{ bamboo_master_application_folder }}/atlassian-bamboo-{{ bamboo_master.version }}"
 
-- name: "Install JDK"
-  yum:
-    name: "java-{{ openjdk_version }}-openjdk"
-    state: installed
-
-- name: Create app and data folders
-  file:
-    name: "{{ item }}"
-    state: directory
-  with_items:
-    - "{{ bamboo_master_application_folder }}"
-    - "{{ bamboo_master_data_folder }}"
-
 - name: Add local user
   user:
     name: "{{ bamboo_master_user }}"
     home: "{{ bamboo_master_data_folder }}"
 
-- name: Set permissions for app and data folders
+- name: Create app and data folders
   file:
     name: "{{ item }}"
     state: directory
@@ -39,11 +26,24 @@
     - ansible_local.bamboo.version is defined
     - bamboo_master.version | version_compare(ansible_local.bamboo.version, '<')
 
-- name: Stop when upgrade
+- name: Stop when upgrade (systemd)
   systemd:
     name: bamboo
     state: stopped
   when:
+    - ansible_service_mgr == 'systemd'
+    - ansible_local is defined
+    - ansible_local.bamboo is defined
+    - ansible_local.bamboo.version is defined
+    - bamboo_master.version | version_compare(ansible_local.bamboo.version, '>')
+  notify: restart bamboo
+
+- name: Stop when upgrade (sysv)
+  service:
+    name: bamboo
+    state: stopped
+  when:
+    - ansible_service_mgr == 'service'
     - ansible_local is defined
     - ansible_local.bamboo is defined
     - ansible_local.bamboo.version is defined
@@ -59,6 +59,7 @@
     keep_newer: yes
     owner: "{{ bamboo_master_user }}"
     group: "{{ bamboo_master_user }}"
+    creates: "{{ bamboo_master_binary_folder }}"
   changed_when: False
 
 - name: Configure bamboo server (server.xml)
@@ -67,41 +68,20 @@
     dest: "{{ bamboo_master_binary_folder }}/conf/server.xml"
   notify: restart bamboo
 
-- name: Install crontabs
-  yum:
-    name: crontabs
-    state: installed
-
-- name: Add cronjob for cleanup Bamboo logs
-  cron:
-    name: cleanupbamboologs
-    special_time: daily
-    state: present
-    job: "/usr/bin/find {{ bamboo_master_binary_folder }}/logs/ -name *.log -type f -mtime +7 -exec rm  {} \\;"
-
-- name: Add cronjob for cleanup Bamboo build-dir
-  cron:
-    name: cleanupbamboobuilddir
-    hour: 03
-    minute: 15
-    weekday: 0 # sunday
-    state: present
-    job: "/usr/bin/find {{ bamboo_master_data_folder }}/xml-data/build-dir/ -maxdepth 1 -type d -mtime +1 -exec rm -rf {} \\;"
-
-- name: Add cronjob for cleanup maven repository cache
-  cron:
-    name: cleanupbamboomavenrepo
-    hour: 03
-    minute: 15
-    weekday: 0 # sunday
-    state: present
-    job: "/usr/bin/find {{ bamboo_master_data_folder }}/.m2/repository/ -maxdepth 1 -type d -mtime +1 -exec rm -rf {} \\;"
-
 - name: Install bamboo systemd unit script
   template:
     src: bamboo.service.j2
     dest: /etc/systemd/system/bamboo.service
     mode: 0744
+  when: ansible_service_mgr == 'systemd'
+  notify: restart bamboo
+
+- name: Install bamboo sysv init script
+  template:
+    src: bamboo.init.j2
+    dest: /etc/init.d/bamboo
+    mode: 0744
+  when: ansible_service_mgr == 'service'
   notify: restart bamboo
 
 - name: Set bamboo.home property variable
@@ -124,27 +104,17 @@
       replace: 'JVM_MAXIMUM_MEMORY="{{ bamboo_master_jvm_memory }}'
   notify: restart bamboo
 
-- name: Ensure service is running
+- name: Ensure service is running (systemd)
   systemd:
     name: bamboo
     state: started
     enabled: yes
     daemon_reload: yes
+  when: ansible_service_mgr == 'systemd'
 
-- name: Ensure ansible facts folder exists
-  file:
-    name: /etc/ansible/facts.d/
-    state: directory
-    recurse: yes
-
-- name: Ensure bamboo facts exists
-  file:
-    name: /etc/ansible/facts.d/bamboo.fact
-    state: touch
-  changed_when: False
-
-- name: Update bamboo facts
-  template:
-    src: bamboo.fact.j2
-    dest: /etc/ansible/facts.d/bamboo.fact
-  notify: restart bamboo
+- name: Ensure service is running (sysv)
+  service:
+    name: bamboo
+    state: started
+    enabled: yes
+  when: ansible_service_mgr == 'service'

--- a/tasks/cron.yml
+++ b/tasks/cron.yml
@@ -1,0 +1,37 @@
+---
+- name: Install crontabs (RedHat)
+  yum:
+    name: crontabs
+    state: installed
+  when: ansible_os_family == 'RedHat'
+
+- name: Install crontabs (Debian)
+  apt:
+    name: cron
+    state: installed
+  when: ansible_os_family == 'Debian'
+
+- name: Add cronjob for cleanup Bamboo logs
+  cron:
+    name: cleanupbamboologs
+    special_time: daily
+    state: present
+    job: "/usr/bin/find {{ bamboo_master_binary_folder }}/logs/ -name *.log -type f -mtime +7 -exec rm  {} \\;"
+
+- name: Add cronjob for cleanup Bamboo build-dir
+  cron:
+    name: cleanupbamboobuilddir
+    hour: 03
+    minute: 15
+    weekday: 0 # sunday
+    state: present
+    job: "/usr/bin/find {{ bamboo_master_data_folder }}/xml-data/build-dir/ -maxdepth 1 -type d -mtime +1 -exec rm -rf {} \\;"
+
+- name: Add cronjob for cleanup maven repository cache
+  cron:
+    name: cleanupbamboomavenrepo
+    hour: 03
+    minute: 15
+    weekday: 0 # sunday
+    state: present
+    job: "/usr/bin/find {{ bamboo_master_data_folder }}/.m2/repository/ -maxdepth 1 -type d -mtime +1 -exec rm -rf {} \\;"

--- a/tasks/fact.yml
+++ b/tasks/fact.yml
@@ -1,0 +1,18 @@
+---
+- name: Ensure ansible facts folder exists
+  file:
+    name: /etc/ansible/facts.d/
+    state: directory
+    recurse: yes
+
+- name: Ensure bamboo facts exists
+  file:
+    name: /etc/ansible/facts.d/bamboo.fact
+    state: touch
+  changed_when: False
+
+- name: Update bamboo facts
+  template:
+    src: bamboo.fact.j2
+    dest: /etc/ansible/facts.d/bamboo.fact
+  notify: restart bamboo

--- a/tasks/jdk-Debian.yml
+++ b/tasks/jdk-Debian.yml
@@ -1,0 +1,14 @@
+---
+- name: add OpenJDK PPA for Ubuntu 14.04 and lower
+  apt_repository:
+    repo: ppa:openjdk-r/ppa
+
+- name: install OpenJDK
+  apt:
+    name: openjdk-{{ openjdk_version.split('.')[-2] }}-jdk
+    cache_valid_time: 1800
+
+- name: set default java to OpenJDK
+  alternatives:
+    name: java
+    path: /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java

--- a/tasks/jdk-RedHat.yml
+++ b/tasks/jdk-RedHat.yml
@@ -1,0 +1,6 @@
+---
+- name: "Install JDK"
+  yum:
+    name: "java-{{ openjdk_version }}-openjdk"
+    state: installed
+  when: ansible_os_family == 'RedHat'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,17 @@
 ---
-- include: bamboo.yml
+- include_tasks: jdk-{{ ansible_os_family }}.yml
+  when: bamboo_include_jdk
+  tags:
+    - bamboo_jdk
+    - bamboo
+- include_tasks: bamboo.yml
   tags: bamboo
+- include_tasks: cron.yml
+  when: bamboo_include_cron
+  tags:
+    - bamboo
+    - bamboo_cron
+- include_tasks: fact.yml
+  tags:
+    - bamboo
+    - bamboo_facts

--- a/templates/bamboo.init.j2
+++ b/templates/bamboo.init.j2
@@ -1,0 +1,55 @@
+#!/bin/sh
+set -e
+### BEGIN INIT INFO
+# Provides: bamboo
+# Required-Start: $local_fs $remote_fs $network $time
+# Required-Stop: $local_fs $remote_fs $network $time
+# Should-Start: $syslog
+# Should-Stop: $syslog
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
+# Short-Description: Atlassian Bamboo Server
+### END INIT INFO
+# INIT Script
+######################################
+
+# Define some variables
+# Name of app ( bamboo, Confluence, etc )
+APP=bamboo
+# Name of the user to run as
+USER={{ bamboo_master_user }}
+# Location of application's bin directory
+BASE={{ bamboo_master_binary_folder }}
+BAMBOO_HOME={{ bamboo_master_data_folder }}
+CATALINA_PID="$BASE/bin/catalina.pid"
+
+case "$1" in
+  # Start command
+  start)
+    echo "Starting $APP"
+    export BAMBOO_HOME=${BAMBOO_HOME}
+    export CATALINA_PID=${CATALINA_PID}
+    start-stop-daemon --start --chuid $USER --pidfile $CATALINA_PID --background --exec "$BASE/bin/catalina.sh" -- start
+    ;;
+  # Stop command
+  stop)
+    echo "Stopping $APP"
+    start-stop-daemon --stop --chuid $USER --pidfile $CATALINA_PID
+    echo "$APP stopped successfully"
+    ;;
+   # Restart command
+   restart)
+        $0 stop
+        sleep 5
+        $0 start
+        ;;
+    status)
+        start-stop-daemon --status --user $USER --pidfile $CATALINA_PID
+        ;;
+  *)
+    echo "Usage: /etc/init.d/$APP {start|restart|stop}"
+    exit 1
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
This module was the most minimal I could find but I needed support for Ubuntu 14.04. I've broken up some bits to make it easier to switch between CentOS or Debian stuff.

* Initial support for Ubuntu 14.04 (and may be already working on other Debian based distributions).
* Added switches `bamboo_include_cron` and `bamboo_include_jdk` to disable installing of JDK or cron parts (I handle these in separate roles but the included changes should work).
* Added template for sysv init script (Ubuntu 14.04 is not systemd based).
* Removed a redundant `file` task that was just setting permissions (permissions can be set at creation).
* Added `creates` to the file download so it isn't needlessly downloading the extracted folder again (not sure if there was a reason this was desired).

Feel free to accept or close. If you are interested in the changes but want some edits, let me know and I can work on fleshing it out more.